### PR TITLE
Bug Fix for dhewm 1.5.2

### DIFF
--- a/Doom3.asl
+++ b/Doom3.asl
@@ -18,7 +18,7 @@ state("dhewm3", "dhewm3-1.5.1")
 
 state("dhewm3", "dhewm3-1.5.2")
 {
-    bool isLoading : 0xD45155;
+    bool isLoading : 0x5CB9BC;
     bool isCutscene : "base.dll", 0x51E7B0;
 }
 


### PR DESCRIPTION
I did a test run and the isLoading variable stopped working in the late game. I must have found the wrong address so I found a better one and I hope I tested it properly this time - it seems to work now.